### PR TITLE
Using relative protocol notation for jQuery load.

### DIFF
--- a/_layouts/diva-highlight.html
+++ b/_layouts/diva-highlight.html
@@ -25,7 +25,7 @@
             height: 30px;
         }
     </style>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js" type="text/javascript"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js" type="text/javascript"></script>
     <script src="{{ site.baseurl }}try/js/diva.min.js" type="text/javascript"></script>
     <script type="text/javascript">
         $(document).ready(function() {


### PR DESCRIPTION
This fixes "ran insecure content from".
