### PR TITLE
New: Don't add meta elements to the document

### DIFF
--- a/source/js/diva.js
+++ b/source/js/diva.js
@@ -1663,17 +1663,6 @@ window.divaPlugins = [];
         // Bind touch and orientation change events
         var bindMobileEvents = function()
         {
-            // Prevent resizing (below from http://matt.might.net/articles/how-to-native-iphone-ipad-apps-in-javascript/)
-            var toAppend = [];
-            toAppend.push('<meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1" />');
-
-            // Eliminate URL and button bars if added to home screen
-            toAppend.push('<meta name="apple-mobile-web-app-capable" content="yes" />');
-
-            // Choose how to handle the phone status bar
-            toAppend.push('<meta name="apple-mobile-web-app-status-bar-style" content="black" />');
-            $('head').append(toAppend.join('\n'));
-
             // Block the user from moving the window only if it's not integrated
             if (settings.blockMobileMove)
             {


### PR DESCRIPTION
Previously, Diva appended some meta elements to the document head
if it detected that it was running on a mobile device. These could
interfere with meta elements already on the page, and setting them
is out of scope for a library that can integrate with other other
content in the same document.