### PR TITLE
Fixed: Search parameters included in current URL

### DIFF
--- a/source/js/diva.js
+++ b/source/js/diva.js
@@ -1708,7 +1708,7 @@ window.divaPlugins = [];
         // Returns the URL to the current state of the document viewer (so it should be an exact replica)
         var getCurrentURL = function ()
         {
-            return location.protocol + '//' + location.host + location.pathname + '#' + getURLHash();
+            return location.protocol + '//' + location.host + location.pathname + location.search + '#' + getURLHash();
         };
 
         // updates panelHeight/panelWidth on resize


### PR DESCRIPTION
Previously, search parameters were not included when constructing
the URL of a page. This commit ensures that they are included.

Fixes #288