### PR TITLE
Fixed Rendering issue that caused the images to be only partially rendered

### DIFF
--- a/source/js/tile-coverage-map.js
+++ b/source/js/tile-coverage-map.js
@@ -4,7 +4,7 @@ export default class TileCoverageMap
     {
         this._rows = rows;
         this._cols = cols;
-        this._map = new Array(rows).fill().map(() => new Array(cols).fill(false));
+        this._map = new Array(rows).fill(null).map(() => new Array(cols).fill(false));
     }
 
     isLoaded (row, col)

--- a/source/js/tile-coverage-map.js
+++ b/source/js/tile-coverage-map.js
@@ -4,9 +4,7 @@ export default class TileCoverageMap
     {
         this._rows = rows;
         this._cols = cols;
-        // this._map = rows.fill(cols);
-        // this._map = fill(rows).map(() => fill(cols, false));
-        this._map = new Array(rows).fill(new Array(cols).fill(false));
+        this._map = new Array(rows).fill().map(() => new Array(cols).fill(false));
     }
 
     isLoaded (row, col)


### PR DESCRIPTION
The problem was in the definition of the _map property in the
TileCoverageMap class (Syntax) that caused problems while accessing the
multidimensional array. Fixes #378