### PR TITLE
Added missing argument when calling getPositionForZoomLevel. Solves issue #373

### DIFF
--- a/source/js/viewer-core.js
+++ b/source/js/viewer-core.js
@@ -683,8 +683,6 @@ export default class ViewerCore
             },
             getPosition: (parameters) =>
             {
-                let initialZoomLevel = this.viewerState.oldZoomLevel = this.settings.zoomLevel;
-
                 return getPositionForZoomLevel(parameters.zoomLevel, initialZoomLevel)
             },
             onEnd: (info) =>

--- a/source/js/viewer-core.js
+++ b/source/js/viewer-core.js
@@ -667,7 +667,8 @@ export default class ViewerCore
         };
 
         this.viewerState.options.zoomLevel = newZoomLevel;
-        let initialZoomLevel = this.viewerState.oldZoomLevel = this.settings.zoomLevel;
+        let initialZoomLevel = this.viewerState.oldZoomLevel;
+        this.viewerState.oldZoomLevel = this.settings.zoomLevel;
         const endPosition = getPositionForZoomLevel(newZoomLevel, initialZoomLevel);
         this.viewerState.options.goDirectlyTo = endPosition.anchorPage;
         this.viewerState.verticalOffset = endPosition.verticalOffset;

--- a/source/js/viewer-core.js
+++ b/source/js/viewer-core.js
@@ -683,7 +683,9 @@ export default class ViewerCore
             },
             getPosition: (parameters) =>
             {
-                return getPositionForZoomLevel(parameters.zoomLevel);
+                let initialZoomLevel = this.viewerState.oldZoomLevel = this.settings.zoomLevel;
+
+                return getPositionForZoomLevel(parameters.zoomLevel, initialZoomLevel)
             },
             onEnd: (info) =>
             {


### PR DESCRIPTION
The absence of the argument caused an undefined value of the
initialZoomLevel which is used for computing the viewer state.
Repainting should be possible now right after zooming