### PR TITLE
Added ZoomLevelWillChange Event publishing

### DIFF
--- a/source/js/renderer.js
+++ b/source/js/renderer.js
@@ -480,6 +480,7 @@ export default class Renderer
             {
                 // TODO: Do image preloading, work with that
                 this._setViewportPosition(getPosition(values));
+                this._hooks.onZoomLevelWillChange(values.zoomLevel);
 
                 if (onViewDidTransition)
                 {

--- a/source/js/viewer-core.js
+++ b/source/js/viewer-core.js
@@ -503,6 +503,10 @@ export default class ViewerCore
                 onPageWillLoad: (pageIndex) =>
                 {
                     this.publish('PageWillLoad', pageIndex);
+                },
+                onZoomLevelWillChange: (zoomLevel) =>
+                {
+                    this.publish('ZoomLevelWillChange', zoomLevel)
                 }
             };
 


### PR DESCRIPTION
This is necessary for plugins who want to draw on top of a page in Diva
when a zooming animation is triggered (to have a smooth drawings zoom)