### PR TITLE
Added enable/disable drag scrollable methods

### DIFF
--- a/source/js/diva.js
+++ b/source/js/diva.js
@@ -698,6 +698,26 @@ class Diva
     }
 
     /**
+     * Disables document drag scrolling
+     *
+     * @public
+     */
+    disableDragScrollable ()
+    {
+        this.divaState.viewerCore.disableDragScrollable();
+    }
+
+    /**
+     * Enables document drag scrolling
+     *
+     * @public
+     */
+    enableDragScrollable ()
+    {
+        this.divaState.viewerCore.enableDragScrollable();
+    }
+
+    /**
      * Enter fullscreen mode if currently not in fullscreen mode. If currently in fullscreen
      * mode this will have no effect.
      *

--- a/source/js/viewer-core.js
+++ b/source/js/viewer-core.js
@@ -1384,6 +1384,8 @@ export default class ViewerCore
         if (!this.viewerState.isScrollable)
         {
             this.bindMouseEvents();
+            this.enableDragScrollable();
+
             this.viewerState.options.enableKeyScroll = this.viewerState.initialKeyScroll;
             this.viewerState.options.enableSpaceScroll = this.viewerState.initialSpaceScroll;
             this.viewerState.viewportElement.style.overflow = 'auto';
@@ -1391,14 +1393,20 @@ export default class ViewerCore
         }
     }
 
+    enableDragScrollable ()
+    {
+        if (this.viewerState.viewportObject.hasAttribute('nochilddrag'))
+            this.viewerState.viewportObject.removeAttribute('nochilddrag');
+    }
+
     disableScrollable ()
     {
         if (this.viewerState.isScrollable)
         {
-            // block dragging/double-click zooming
-            if (this.viewerState.innerObject.hasClass('diva-dragger'))
-                this.viewerState.innerObject.mousedown = null;
+            // block dragging
+            this.disableDragScrollable();
 
+            // block double-click zooming
             this.viewerState.outerObject.dblclick = null;
             this.viewerState.outerObject.contextmenu = null;
 
@@ -1413,6 +1421,12 @@ export default class ViewerCore
 
             this.viewerState.isScrollable = false;
         }
+    }
+
+    disableDragScrollable ()
+    {
+        if (!this.viewerState.viewportObject.hasAttribute('nochilddrag'))
+            this.viewerState.viewportObject.setAttribute('nochilddrag', "");
     }
 
     // isValidOption (key, value)


### PR DESCRIPTION
This is needed by plugins like DDMAL/Pixel.js that transform Diva into
a drawing tool. Also fixes #392 