### PR TITLE
Fix markdown syntax

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@
     <img width="382" height="191" src="https://github.com/DDMAL/diva.js/wiki/img/diva-logo-sm.png" />
   </a>
 </p>
+
 Diva.js [![Build Status](https://travis-ci.org/DDMAL/diva.js.svg?branch=master)](http://travis-ci.org/DDMAL/diva.js) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/DDMAL/diva.js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 =========================================
 


### PR DESCRIPTION
Hi,
Thanks for the cool viewer project!

This PR simply fixes collapsed README markdown syntax and display the badges correctly in GitHub web UI.