### PR TITLE
Fixed: Remove reference to plugin in diva source

### DIFF
--- a/source/js/diva.js
+++ b/source/js/diva.js
@@ -34,9 +34,6 @@ class Diva
 {
     constructor (element, options)
     {
-        // for the metadata plugin
-        this.metadata; 
-
         /*
          * If a string is passed in, convert that to an element.
          * */

--- a/source/js/image-manifest.js
+++ b/source/js/image-manifest.js
@@ -12,6 +12,7 @@ export default class ImageManifest
         this.maxRatio = data.dims.max_ratio;
         this.minRatio = data.dims.min_ratio;
         this.itemTitle = data.item_title;
+        this.metadata = data.metadata || null;
 
         // Only given for IIIF manifests
         this.paged = !!data.paged;

--- a/source/js/parse-iiif-manifest.js
+++ b/source/js/parse-iiif-manifest.js
@@ -50,7 +50,23 @@ export default function parseIIIFManifest (manifest)
 
     const pages = new Array(canvases.length);
 
-    let thisCanvas, thisResource, thisImage, otherImages, context, url, info, imageAPIVersion, width, height, maxZoom, canvas, label, imageLabel, zoomDimensions, widthAtCurrentZoomLevel, heightAtCurrentZoomLevel;
+    let thisCanvas,
+        thisResource,
+        thisImage,
+        otherImages,
+        context,
+        url,
+        info,
+        imageAPIVersion,
+        width,
+        height,
+        maxZoom,
+        canvas,
+        label,
+        imageLabel,
+        zoomDimensions,
+        widthAtCurrentZoomLevel,
+        heightAtCurrentZoomLevel;
 
     let lowestMaxZoom = 100;
     let maxRatio = 0;
@@ -103,6 +119,7 @@ export default function parseIIIFManifest (manifest)
         // Prioritize the canvas height / width first, since images may not have h/w
         width = thisCanvas.width || thisImage.width;
         height = thisCanvas.height || thisImage.height;
+
         if (width <= 0 || height <= 0)
         {
             console.warn('Invalid width or height for canvas ' + label + '. Skipping');
@@ -196,6 +213,7 @@ export default function parseIIIFManifest (manifest)
 
     return {
         item_title: manifest.label,
+        metadata: manifest.metadata || null,
         dims: dims,
         max_zoom: lowestMaxZoom,
         pgs: pages,

--- a/source/js/plugins/metadata.js
+++ b/source/js/plugins/metadata.js
@@ -34,13 +34,18 @@ export default class MetadataPlugin
      * Display a modal with the IIIF manifest metadata. Here, viewer refers to the Diva instance (because
      * the toolbar class refers to it as viewer)
      **/
-    handleClick (viewer) 
+    handleClick ()
     {
         // if first click create div elements
         let metadataDiv;
+
+        let metadata = this.core.viewerState.manifest.metadata || null;
+
+        if (!metadata)
+            return null;
+
         if (this.firstClick)
         {
-            let metadata = viewer.metadata;
             metadataDiv = document.createElement('div');
             metadataDiv.id = 'metadataDiv';
             metadataDiv.className = 'diva-modal';
@@ -59,7 +64,7 @@ export default class MetadataPlugin
             let values = document.createElement('DIV');
             values.setAttribute('style', 'width:69%; text-align:left; float:right;');
 
-            for (var i = 0, len = metadata.length; i < len; i++) 
+            for (let i = 0, len = metadata.length; i < len; i++)
             {
                 let lineLabel = document.createElement('div');
                 let bold = document.createElement('b');


### PR DESCRIPTION
This PR removes the hook in the core code for the metadata plugin. In its place it adds the ability to reference the metadata section of the manifest within the parsed version of the IIIF manifest.

It also tidies up a few things. It leaves an open-ended issue which will be filed separately about what to do when there is no metadata in a manifest.

