### PR TITLE
Add setting enableIndexAsLabel.

### DIFF
--- a/source/js/diva.js
+++ b/source/js/diva.js
@@ -66,6 +66,7 @@ class Diva
             enableGridIcon: true,       // A grid view of all the pages
             enableGridControls: 'buttons',  // Specify control of pages per grid row in Grid view. Possible values: 'buttons' (+/-), 'slider'. Any other value disables the controls.
             enableImageTitles: true,    // Adds "Page {n}" title to page images if true
+            enableIndexAsLabel: false,	// Use index numbers instead of page labels in the page n-m display.
             enableKeyScroll: true,      // Captures scrolling using the arrow and page up/down keys regardless of page focus. When off, defers to default browser scrolling behavior.
             enableLinkIcon: true,       // Controls the visibility of the link icon
             enableNonPagedVisibilityIcon: true, // Controls the visibility of the icon to toggle the visibility of non-paged pages. (Automatically hidden if no 'non-paged' pages).

--- a/source/js/toolbar.js
+++ b/source/js/toolbar.js
@@ -124,10 +124,20 @@ export default class Toolbar
             let startLabel = this.settings.manifest.pages[startIndex].l;
             let endLabel = this.settings.manifest.pages[endIndex].l;
 
-            if (startIndex !== endIndex)
-                currentPage.textContent = startLabel + " - " + endLabel;
+            if (startIndex !== endIndex) 
+            {
+            	if (this.settings.enableIndexAsLabel)
+                	currentPage.textContent = startIndex + " - " + endIndex;
+            	else
+            		currentPage.textContent = startLabel + " - " + endLabel;
+            }
             else
-                currentPage.textContent = startLabel;
+        	{
+            	if (this.settings.enableIndexAsLabel)
+            		currentPage.textContent = startIndex;
+            	else
+            		currentPage.textContent = startLabel;
+        	}
         };
 
         this._subscribe('VisiblePageDidChange', updateCurrentPage);


### PR DESCRIPTION
Here is a simple feature that uses index numbers instead of page labels in the toolbar's "n - m"
display.

Maybe the feature name is confusing since page labels are still used in other places.