### PR TITLE
Simple fix for Firefox exception with zero size drawImage().

### DIFF
--- a/source/js/renderer.js
+++ b/source/js/renderer.js
@@ -391,6 +391,12 @@ export default class Renderer
         const destWidth = Math.min(scaledTile.dimensions.width, img.width * scaledTile.scaleRatio) - destXOffset;
         const destHeight = Math.min(scaledTile.dimensions.height, img.height * scaledTile.scaleRatio) - destYOffset;
 
+        // fix for Firefox exception with zero width or height
+        if (destWidth < 1 || destHeight < 1) {
+        	console.error("Tile width or height too small, aborting draw!");
+        	return;
+        }
+        
         const sourceWidth = destWidth / scaledTile.scaleRatio;
         const sourceHeight = destHeight / scaledTile.scaleRatio;
 


### PR DESCRIPTION
Firefox throws IndexSizeError when sourceWidth/Height or
destWidth/Height are zero in drawImage().

This only fixes the symptom. I don't know why we sometimes get zero or
negative tile sizes...