### PR TITLE
Fix clicking search suggestions

### DIFF
--- a/source/js/toolbar.js
+++ b/source/js/toolbar.js
@@ -288,8 +288,9 @@ export default class Toolbar
         {
             gotoPageInput.value = this.textContent;
             inputSuggestions.style.display = 'none';
-
-            let submitEvent = new Event('submit');
+            let submitEvent = new Event('submit', {
+                cancelable: true
+            });
             gotoForm.dispatchEvent(submitEvent);
         });
 


### PR DESCRIPTION
Make the submit event that is created when clicking a search input suggestion cancelable, resolving #481