### PR TITLE
Active page fix

### DIFF
--- a/source/js/document-handler.js
+++ b/source/js/document-handler.js
@@ -165,10 +165,10 @@ function getCentermostPage (renderedPages, layout, viewport)
     const centerPage = maxBy(renderedPages, pageIndex =>
     {
         const dims = layout.getPageDimensions(pageIndex);
-        const imageOffset = layout.getPageOffset(pageIndex, {includePadding: false});
+        const imageOffset = layout.getPageOffset(pageIndex, {includePadding: true});
 
-        const midX = imageOffset.left + (dims.height / 2);
-        const midY = imageOffset.top + (dims.width / 2);
+        const midX = imageOffset.left + (dims.width / 2);
+        const midY = imageOffset.top + (dims.height / 2);
 
         const dx = Math.max(Math.abs(centerX - midX) - (dims.width / 2), 0);
         const dy = Math.max(Math.abs(centerY - midY) - (dims.height / 2), 0);

--- a/source/js/viewer-core.js
+++ b/source/js/viewer-core.js
@@ -1366,19 +1366,28 @@ export default class ViewerCore
         if (!arraysEqual(this.viewerState.currentPageIndices, visiblePages))
         {
             this.viewerState.currentPageIndices = visiblePages;
-            this.viewerState.activePageIndex = activePage;
+            if (this.viewerState.activePageIndex !== activePage)
+            {
+                this.viewerState.activePageIndex = activePage;
+                this.publish("ActivePageDidChange", activePage);
+            }
             this.publish("VisiblePageDidChange", visiblePages);
 
             // Publish an event if the page we're switching to has other images.
             if (this.viewerState.manifest.pages[activePage].otherImages.length > 0)
                 this.publish('VisiblePageHasAlternateViews', activePage);
         }
+        else if (this.viewerState.activePageIndex !== activePage)
+        {
+            this.viewerState.activePageIndex = activePage;
+            this.publish("ActivePageDidChange", activePage);
+        }
 
         function arraysEqual (a, b)
         {
             if (a.length !== b.length)
                 return false;
-            
+
             for (let i = 0, len = a.length; i < len; i++)
             {
                 if (a[i] !== b[i])


### PR DESCRIPTION
Change how the center page is calculated (5105174) by correcting the usage of width and height and including padding. It seems padding should be included since that is part of what appears in the layout and affects where the page would be rendered.

An event 'ActivePageDidChange' is added since the active page might change while visible pages do not (e.g. pages 0 and 1 are visible but active page changes from 0 to 1 or vice versa).