### PR TITLE
Fix incorrect path for package entry point.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "diva.js",
   "version": "6.0.1",
   "description": "Diva.js",
-  "main": "build/js/diva.js",
+  "main": "build/diva.js",
   "scripts": {
     "test": "npm run build:production && karma start",
     "lint": "jshint --reporter=node_modules/jshint-stylish source/js test",


### PR DESCRIPTION
The current value of `main` in package.json is `build/js/diva.js`. Files are actually just built to `build`, so the addition of the directory `js` makes the node package unusable.