### PR TITLE
Format imports in standard way

### DIFF
--- a/source/js/document-handler.js
+++ b/source/js/document-handler.js
@@ -1,4 +1,4 @@
-import maxBy from 'lodash.maxby';
+import { maxBy } from 'lodash';
 import PageToolsOverlay from './page-tools-overlay';
 
 

--- a/source/js/grid-handler.js
+++ b/source/js/grid-handler.js
@@ -1,4 +1,4 @@
-import maxBy from 'lodash.maxby';
+import { maxBy } from 'lodash';
 
 export default class GridHandler
 {


### PR DESCRIPTION
This is just so when diva.js is used as an uncompiled dependency
standard resolvers can properly find the function.