### PR TITLE
Fixed: Scope injected styles to Diva's root to prevent global style leak

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,10 +1,7 @@
 /* App layout, canvas, and throbber styles. */
 
-:root {
-  color-scheme: light;
-}
-
-* {
+.diva-app,
+.diva-app * {
   box-sizing: border-box;
 }
 
@@ -40,6 +37,7 @@
 }
 
 .diva-app {
+  color-scheme: light;
   padding: 12px 24px;
   height: 100%;
   display: flex;


### PR DESCRIPTION
## Problem

diva.js injects its stylesheet into `document.head` as `<style id="diva-inline-styles">`. Two rules in it were unscoped and therefore affected the entire embedding page, not just Diva:

- `* { box-sizing: border-box }` — reapplied the border-box model to every element on the host page, shifting the layout of any component that relied on the default `content-box`.
- `:root { color-scheme: light }` — forced the document's color scheme, overriding host dark mode and changing native control rendering.

## Fix

Scope both rules to Diva's own root (`src/styles/app.css`):

- box-sizing is now applied to `.diva-app` and its descendants only;
- `color-scheme: light` moved from `:root` onto the `.diva-app` rule.
