### PR TITLE
Fixed: Scope injected CSS to the viewer

### DIFF
--- a/browser-tests/auth.spec.ts
+++ b/browser-tests/auth.spec.ts
@@ -468,7 +468,7 @@ test("falls back from silent external auth and deduplicates active login", async
         await instance.auth.resolve({sourceId, url, isStatic : false}, new AbortController().signal);
     }, {sourceId : `${origin}/mock/image-1/info.json`, url : `${origin}/mock/image-1/info.json`});
     expect(infoRequests.get(`${origin}/mock/image-1/info.json`)).toBe(1);
-    await page.locator(".modal-close-action button").click();
+    await page.locator(".diva-modal-close-action button").click();
     await expect(page.locator(".diva-modal.is-page-view")).toBeHidden();
 
     await page.evaluate(async () => {
@@ -780,11 +780,11 @@ test("cancels superseded previews, source resolutions, and destroyed viewers", a
 
     await page.getByRole("button", {name : "Page View"}).click();
     await expect(page.locator(".diva-modal.is-page-view")).toBeVisible();
-    await page.locator(".modal-close-action button").click();
+    await page.locator(".diva-modal-close-action button").click();
     await page.evaluate((id) => (window as any).diva.auth.invalidateSources([ id ]), sourceId);
     await page.getByRole("button", {name : "Page View"}).click();
     await expect.poll(() => infoRequests).toBe(2);
-    await page.locator(".modal-close-action button").click();
+    await page.locator(".diva-modal-close-action button").click();
     await expect.poll(() => page.evaluate(() => ({
                                               inflight : (window as any).diva.auth.inflight.size,
                                               pending : (window as any).diva.auth.pending.size,

--- a/browser-tests/auth.spec.ts
+++ b/browser-tests/auth.spec.ts
@@ -230,7 +230,7 @@ test("loads only nearby sidebar thumbnails", async ({page}, testInfo) => {
     const initiallyLoaded = thumbnailRequests.size;
     expect(initiallyLoaded).toBeLessThan(pageCount);
 
-    await page.locator(".thumbs").evaluate((element) => { element.scrollTop = element.scrollHeight; });
+    await page.locator(".diva-thumbs").evaluate((element) => { element.scrollTop = element.scrollHeight; });
     await expect.poll(() => thumbnailRequests.size).toBeGreaterThan(initiallyLoaded);
 });
 
@@ -453,15 +453,15 @@ test("falls back from silent external auth and deduplicates active login", async
     await openHarness(page, `${origin}/mock/manifest`, testInfo);
     await expect(page.locator(".diva-auth-dialog")).toBeVisible();
     expect(externalTokenRequests).toBe(1);
-    await expect(page.locator(".thumbs-image--protected")).toHaveCount(2);
+    await expect(page.locator(".diva-thumbs-image--protected")).toHaveCount(2);
     await page.locator("button[data-diva-auth-flow]").click();
     await expect(page.locator(".diva-auth-dialog")).toBeHidden({timeout : 10000});
     await expect.poll(() => probeRequests.filter((request) => request.authorization === "Bearer token-1").length).toBe(1);
     await page.getByRole("button", {name : "Page View"}).click();
-    await expect(page.locator(".modal.is-page-view")).toBeVisible();
+    await expect(page.locator(".diva-modal.is-page-view")).toBeVisible();
     await expect.poll(() => infoRequests.get(`${origin}/mock/image-1/info.json`) || 0).toBe(1);
     await expect.poll(() => infoRequests.get(`${origin}/mock/image-2/info.json`) || 0).toBe(1);
-    await expect(page.locator("img.thumbs-image").first()).toHaveAttribute("crossorigin", "use-credentials");
+    await expect(page.locator("img.diva-thumbs-image").first()).toHaveAttribute("crossorigin", "use-credentials");
 
     await page.evaluate(async ({sourceId, url}) => {
         const instance = (window as any).diva;
@@ -469,7 +469,7 @@ test("falls back from silent external auth and deduplicates active login", async
     }, {sourceId : `${origin}/mock/image-1/info.json`, url : `${origin}/mock/image-1/info.json`});
     expect(infoRequests.get(`${origin}/mock/image-1/info.json`)).toBe(1);
     await page.locator(".modal-close-action button").click();
-    await expect(page.locator(".modal.is-page-view")).toBeHidden();
+    await expect(page.locator(".diva-modal.is-page-view")).toBeHidden();
 
     await page.evaluate(async () => {
         const viewer = document.querySelector("osd-viewer") as any;
@@ -779,7 +779,7 @@ test("cancels superseded previews, source resolutions, and destroyed viewers", a
     await expect.poll(() => infoRequests).toBe(1);
 
     await page.getByRole("button", {name : "Page View"}).click();
-    await expect(page.locator(".modal.is-page-view")).toBeVisible();
+    await expect(page.locator(".diva-modal.is-page-view")).toBeVisible();
     await page.locator(".modal-close-action button").click();
     await page.evaluate((id) => (window as any).diva.auth.invalidateSources([ id ]), sourceId);
     await page.getByRole("button", {name : "Page View"}).click();
@@ -792,7 +792,7 @@ test("cancels superseded previews, source resolutions, and destroyed viewers", a
                                           })))
         .toEqual({inflight : 0, pending : 0, requests : 0});
     releases.shift()?.();
-    await expect(page.locator(".modal.is-page-view")).toBeHidden();
+    await expect(page.locator(".diva-modal.is-page-view")).toBeHidden();
     await expect(page.locator(".diva-image-unavailable")).toHaveCount(0);
 
     await page.evaluate(({id, url}) => {

--- a/browser-tests/public-api.spec.ts
+++ b/browser-tests/public-api.spec.ts
@@ -320,7 +320,7 @@ test("positions a distant initial image with final page geometry", async ({page}
 });
 
 test("configures the initial sidebar width and retains the default", async ({page}) => {
-    const sidebar = page.locator(".sidebar-panel");
+    const sidebar = page.locator(".diva-sidebar-panel");
     await page.getByRole("button", {name : "Show Sidebar"}).evaluate((button: HTMLButtonElement) => button.click());
     await expect(sidebar).toHaveCSS("width", "320px");
 
@@ -431,7 +431,7 @@ test("bolds ranges containing the current page in the contents index", async ({p
     await expect(sectionA).not.toHaveClass(/is-current/);
 
     await page.getByRole("button", {name : "On this page"}).evaluate((button: HTMLButtonElement) => button.click());
-    await expect(page.locator(".contents-button.is-current")).toHaveCount(0);
+    await expect(page.locator(".diva-contents-button.is-current")).toHaveCount(0);
 });
 
 test("bolds ranges containing either page of a two-up spread", async ({page}) => {
@@ -560,7 +560,7 @@ test("indents nested ranges in the contents index", async ({page}) => {
     expect(parentBox).not.toBeNull();
     expect(childBox!.x - parentBox!.x).toBeGreaterThanOrEqual(18);
     expect(grandchildBox!.x - childBox!.x).toBeGreaterThanOrEqual(18);
-    await expect(page.locator(".contents-list-nested").first()).toHaveCSS("border-left-width", "1px");
+    await expect(page.locator(".diva-contents-list-nested").first()).toHaveCSS("border-left-width", "1px");
 });
 
 test("keeps the previous resource when a replacement request fails", async ({page}) => {

--- a/src/View.elm
+++ b/src/View.elm
@@ -62,7 +62,7 @@ view model =
                 , View.Sidebar.viewSidebarResizer model
                 , View.Sidebar.viewSidebarPanel model
                 ]
-            , div [ HA.class "required-statement-dock" ]
+            , div [ HA.class "diva-required-statement-dock" ]
                 [ viewMaybe (Lazy.lazy viewRequiredStatement) (requiredStatementTextFor model) ]
             , View.PageViewModal.viewPageViewModal model
             , View.ManifestInfoModal.viewManifestInfoModal model
@@ -177,7 +177,7 @@ viewRequiredStatement valueText =
 
     else
         div
-            [ HA.class "required-statement" ]
+            [ HA.class "diva-required-statement" ]
             (HtmlRenderer.renderHtml valueText)
 
 
@@ -197,13 +197,13 @@ viewThrobber =
             ]
     in
     div
-        [ HA.class "throbber-overlay" ]
+        [ HA.class "diva-throbber-overlay" ]
         [ div
-            [ HA.class "throbber" ]
+            [ HA.class "diva-throbber" ]
             (List.map
                 (\delay ->
                     div
-                        [ HA.class "throbber-cube"
+                        [ HA.class "diva-throbber-cube"
                         , HA.style "animation-delay" (String.fromFloat delay ++ "s")
                         ]
                         []
@@ -216,16 +216,16 @@ viewThrobber =
 viewViewerStatusModal : ( String, String, Bool ) -> Html Msg
 viewViewerStatusModal ( titleText, message, isError ) =
     div
-        [ HA.class "viewer-status-overlay" ]
+        [ HA.class "diva-viewer-status-overlay" ]
         [ div
-            [ HA.class "modal is-narrow" ]
+            [ HA.class "diva-modal is-narrow" ]
             [ div
-                [ HA.class "modal-header" ]
-                [ div [ HA.class "modal-title" ] [ text titleText ] ]
+                [ HA.class "diva-modal-header" ]
+                [ div [ HA.class "diva-modal-title" ] [ text titleText ] ]
             , div
-                [ HA.class "modal-body is-no-sidebar" ]
+                [ HA.class "diva-modal-body is-no-sidebar" ]
                 [ div
-                    [ classList [ ( "status", True ), ( "is-error", isError ) ] ]
+                    [ classList [ ( "diva-status", True ), ( "is-error", isError ) ] ]
                     [ text message ]
                 ]
             ]
@@ -234,7 +234,7 @@ viewViewerStatusModal ( titleText, message, isError ) =
 
 viewZoomIndicator : String -> Html Msg
 viewZoomIndicator zoomText =
-    div [ HA.class "viewer-zoom-indicator" ] [ text zoomText ]
+    div [ HA.class "diva-viewer-zoom-indicator" ] [ text zoomText ]
 
 
 viewerStatus : Model -> Maybe ( String, String, Bool )

--- a/src/View/CollectionExplorer.elm
+++ b/src/View/CollectionExplorer.elm
@@ -19,7 +19,7 @@ viewCollectionResizer model =
         ResourceLoadedCollection _ ->
             div
                 [ classList
-                    [ ( "collection-resizer", True )
+                    [ ( "diva-collection-resizer", True )
                     , ( "is-hidden", not model.collectionSidebarVisible )
                     ]
                 , Events.on "mousedown"
@@ -64,7 +64,7 @@ viewCollectionPanel model collectionState =
     in
     div
         [ classList
-            [ ( "collection-panel", True )
+            [ ( "diva-collection-panel", True )
             , ( "is-fullscreen", model.fullscreen )
             , ( "is-hidden", not model.collectionSidebarVisible )
             ]
@@ -77,18 +77,18 @@ viewCollectionPanel model collectionState =
             )
         ]
         [ div
-            [ HA.class "collection-header" ]
-            [ div [ HA.class "collection-title" ] [ text labelText ]
+            [ HA.class "diva-collection-header" ]
+            [ div [ HA.class "diva-collection-title" ] [ text labelText ]
             , viewMaybe
                 (\summary ->
-                    div [ HA.class "collection-summary" ] [ text (extractLabelFromLanguageMap model.detectedLanguage summary) ]
+                    div [ HA.class "diva-collection-summary" ] [ text (extractLabelFromLanguageMap model.detectedLanguage summary) ]
                 )
                 collection.summary
             ]
         , div
-            [ HA.class "sidebar-content" ]
+            [ HA.class "diva-sidebar-content" ]
             [ div
-                [ HA.class "sidebar-pane is-scroll" ]
+                [ HA.class "diva-sidebar-pane is-scroll" ]
                 [ viewCollectionTree model.detectedLanguage collectionState collection.items ]
             ]
         ]
@@ -97,7 +97,7 @@ viewCollectionPanel model collectionState =
 viewCollectionTree : Language -> CollectionState -> List CollectionItem -> Html Msg
 viewCollectionTree language collectionState items =
     ul
-        [ HA.class "collection-list diva-list-reset" ]
+        [ HA.class "diva-collection-list diva-list-reset" ]
         (List.map (Lazy.lazy3 viewCollectionItem language collectionState) items)
 
 
@@ -113,7 +113,7 @@ viewManifestItem language collectionState manifest =
     li []
         [ button
             [ classList
-                [ ( "manifest-tree-item", True )
+                [ ( "diva-manifest-tree-item", True )
                 , ( "diva-ui-button", True )
                 , ( "is-active", isActive )
                 ]
@@ -148,7 +148,7 @@ viewNestedCollection language collectionState collection =
 
                     loadingView =
                         if isLoading then
-                            [ div [ HA.class "contents-empty" ] [ text "Loading…" ] ]
+                            [ div [ HA.class "diva-contents-empty" ] [ text "Loading…" ] ]
 
                         else
                             []
@@ -159,13 +159,13 @@ viewNestedCollection language collectionState collection =
                 []
     in
     li
-        [ HA.class "collection-tree-item" ]
+        [ HA.class "diva-collection-tree-item" ]
         (button
-            [ HA.class "collection-node-button diva-ui-button"
+            [ HA.class "diva-collection-node-button diva-ui-button"
             , type_ "button"
             , Events.onClick (UserClickedCollectionItem collection.id)
             ]
-            [ div [ HA.class "collection-expand-icon" ] [ text expandIcon ]
+            [ div [ HA.class "diva-collection-expand-icon" ] [ text expandIcon ]
             , text labelText
             ]
             :: childrenView

--- a/src/View/CollectionExplorer.elm
+++ b/src/View/CollectionExplorer.elm
@@ -97,7 +97,7 @@ viewCollectionPanel model collectionState =
 viewCollectionTree : Language -> CollectionState -> List CollectionItem -> Html Msg
 viewCollectionTree language collectionState items =
     ul
-        [ HA.class "collection-list list-reset" ]
+        [ HA.class "collection-list diva-list-reset" ]
         (List.map (Lazy.lazy3 viewCollectionItem language collectionState) items)
 
 
@@ -114,7 +114,7 @@ viewManifestItem language collectionState manifest =
         [ button
             [ classList
                 [ ( "manifest-tree-item", True )
-                , ( "ui-button", True )
+                , ( "diva-ui-button", True )
                 , ( "is-active", isActive )
                 ]
             , type_ "button"
@@ -161,7 +161,7 @@ viewNestedCollection language collectionState collection =
     li
         [ HA.class "collection-tree-item" ]
         (button
-            [ HA.class "collection-node-button ui-button"
+            [ HA.class "collection-node-button diva-ui-button"
             , type_ "button"
             , Events.onClick (UserClickedCollectionItem collection.id)
             ]

--- a/src/View/Helpers.elm
+++ b/src/View/Helpers.elm
@@ -33,7 +33,7 @@ viewButtonWithAttributes extraAttrs config =
 
                 baseAttrs =
                     [ classList
-                        [ ( "canvas-toolbar-button", True )
+                        [ ( "diva-canvas-toolbar-button", True )
                         , ( "is-disabled", isDisabled )
                         , ( "is-fullscreen", config.isFullscreen )
                         ]
@@ -49,7 +49,7 @@ viewButtonWithAttributes extraAttrs config =
                     HA.disabled True :: (extraAttrs ++ baseAttrs)
     in
     div
-        [ HA.class "canvas-toolbar-item"
+        [ HA.class "diva-canvas-toolbar-item"
         , HA.attribute "data-tooltip" config.label
         ]
         [ button buttonAttrs [ config.icon ]

--- a/src/View/ManifestInfoModal.elm
+++ b/src/View/ManifestInfoModal.elm
@@ -17,9 +17,9 @@ viewManifestInfoModal : Model -> Html Msg
 viewManifestInfoModal model =
     if model.manifestInfoOpen then
         div
-            [ HA.class "modal-overlay" ]
+            [ HA.class "diva-modal-overlay" ]
             [ div
-                [ HA.class "modal is-narrow" ]
+                [ HA.class "diva-modal is-narrow" ]
                 [ viewHeader model
                 , currentManifest model
                     |> viewBody model
@@ -214,12 +214,12 @@ viewBody model maybeManifest =
             viewMaybe (viewLogoBlock model.detectedLanguage) maybeManifest
     in
     div
-        [ HA.class "modal-body is-two-column" ]
+        [ HA.class "diva-modal-body is-two-column" ]
         [ div
-            [ HA.class "metadata-body" ]
+            [ HA.class "diva-metadata-body" ]
             (List.map viewRow rows)
         , div
-            [ HA.class "manifest-info-logo-wrap" ]
+            [ HA.class "diva-manifest-info-logo-wrap" ]
             [ logoBlock ]
         ]
 
@@ -227,14 +227,14 @@ viewBody model maybeManifest =
 viewHeader : { a | fullscreen : Bool } -> Html Msg
 viewHeader { fullscreen } =
     div
-        [ HA.class "modal-header" ]
+        [ HA.class "diva-modal-header" ]
         [ div
-            [ HA.class "modal-title" ]
+            [ HA.class "diva-modal-title" ]
             [ text "Manifest Info" ]
         , div
-            [ HA.class "modal-actions" ]
+            [ HA.class "diva-modal-actions" ]
             [ div
-                [ HA.class "modal-close-action" ]
+                [ HA.class "diva-modal-close-action" ]
                 [ viewButton
                     { label = "Close"
                     , icon = Icons.close
@@ -275,7 +275,7 @@ viewLogoBlock language manifest =
             [ viewMaybe
                 (\url ->
                     img
-                        [ HA.class "manifest-info-logo"
+                        [ HA.class "diva-manifest-info-logo"
                         , src url
                         , alt "Manifest logo"
                         ]
@@ -305,9 +305,9 @@ viewLogoBlock language manifest =
 viewRow : ( String, Html Msg ) -> Html Msg
 viewRow ( labelText, valueNode ) =
     div
-        [ HA.class "metadata-item" ]
-        [ div [ HA.class "metadata-label" ] [ text labelText ]
-        , div [ HA.class "metadata-value" ] [ valueNode ]
+        [ HA.class "diva-metadata-item" ]
+        [ div [ HA.class "diva-metadata-label" ] [ text labelText ]
+        , div [ HA.class "diva-metadata-value" ] [ valueNode ]
         ]
 
 

--- a/src/View/PageViewModal.elm
+++ b/src/View/PageViewModal.elm
@@ -21,13 +21,13 @@ viewPageViewModal model =
     if model.pageViewOpen then
         div
             [ classList
-                [ ( "modal-overlay", True )
+                [ ( "diva-modal-overlay", True )
                 , ( "is-fullscreen", model.pageViewFullscreen )
                 ]
             ]
             [ div
                 [ classList
-                    [ ( "modal", True )
+                    [ ( "diva-modal", True )
                     , ( "is-fullscreen", model.pageViewFullscreen )
                     , ( "is-page-view", not model.pageViewFullscreen )
                     ]
@@ -387,7 +387,7 @@ viewAdvancedColourAdjustGroup model =
         "Advanced colour adjust"
         (viewFilterRow
             [ button
-                [ HA.class "filter-reset"
+                [ HA.class "diva-filter-reset"
                 , type_ "button"
                 , onClick UserResetAltColourAdjust
                 ]
@@ -468,7 +468,7 @@ viewColourAdjustGroup model =
 viewColourInput : String -> (String -> Msg) -> Html Msg
 viewColourInput colourValue onChange =
     input
-        [ HA.class "filter-color-input"
+        [ HA.class "diva-filter-color-input"
         , type_ "color"
         , value colourValue
         , onInput onChange
@@ -525,17 +525,17 @@ viewFilterGroup model groupId title items =
         isExpanded =
             Set.member groupId model.filterGroupExpanded
     in
-    div [ HA.class "filter-group" ]
+    div [ HA.class "diva-filter-group" ]
         (button
             [ classList
-                [ ( "filter-title-button", True )
+                [ ( "diva-filter-title-button", True )
                 , ( "is-collapsed", not isExpanded )
                 ]
             , onClick (UserToggledFilterGroup groupId)
             ]
             [ span
                 [ classList
-                    [ ( "filter-title-icon", True )
+                    [ ( "diva-filter-title-icon", True )
                     , ( "is-expanded", isExpanded )
                     ]
                 ]
@@ -554,24 +554,24 @@ viewFilterGroup model groupId title items =
 viewFilterJsonGroup : Model -> Html Msg
 viewFilterJsonGroup model =
     viewFilterGroup model
-        "filter-json"
+        "diva-filter-json"
         "Import / Export Filter Settings"
         [ viewFilterRow
             [ button
-                [ HA.class "filter-reset"
+                [ HA.class "diva-filter-reset"
                 , type_ "button"
                 , onClick UserCopiedFilterJson
                 ]
                 [ text "Show JSON" ]
             , button
-                [ HA.class "filter-reset"
+                [ HA.class "diva-filter-reset"
                 , type_ "button"
                 , onClick UserAppliedFilterJson
                 ]
                 [ text "Apply" ]
             ]
         , textarea
-            [ HA.class "filter-json"
+            [ HA.class "diva-filter-json"
             , value model.filtersJsonInput
             , onInput UserUpdatedFilterJsonInput
             , rows 6
@@ -579,7 +579,7 @@ viewFilterJsonGroup model =
             []
         , case model.filtersJsonError of
             Just err ->
-                div [ HA.class "filter-json-error" ] [ text err ]
+                div [ HA.class "diva-filter-json-error" ] [ text err ]
 
             Nothing ->
                 emptyHtml
@@ -588,7 +588,7 @@ viewFilterJsonGroup model =
 
 viewFilterRow : List (Html Msg) -> Html Msg
 viewFilterRow items =
-    div [ HA.class "filter-row" ] items
+    div [ HA.class "diva-filter-row" ] items
 
 
 viewImageChoiceItem : Auth.Model -> Int -> Int -> PageImage -> Html Msg
@@ -599,9 +599,9 @@ viewImageChoiceItem auth selectedIndex index image =
     in
     button
         [ classList
-            [ ( "page-view-choice", True )
-            , ( "ui-card", True )
-            , ( "ui-card--dark", True )
+            [ ( "diva-page-view-choice", True )
+            , ( "diva-ui-card", True )
+            , ( "diva-ui-card--dark", True )
             , ( "is-active", isActive )
             ]
         , type_ "button"
@@ -610,7 +610,7 @@ viewImageChoiceItem auth selectedIndex index image =
         [ case Auth.thumbnailCrossOrigin image.sourceId auth of
             Just crossOrigin ->
                 img
-                    [ HA.class "page-view-choice-thumb"
+                    [ HA.class "diva-page-view-choice-thumb"
                     , src image.thumbUrl
                     , alt image.label
                     , HA.attribute "loading" "lazy"
@@ -620,12 +620,12 @@ viewImageChoiceItem auth selectedIndex index image =
 
             Nothing ->
                 div
-                    [ HA.class "page-view-choice-thumb page-view-choice-thumb--protected"
+                    [ HA.class "diva-page-view-choice-thumb diva-page-view-choice-thumb--protected"
                     , HA.attribute "aria-label" "Protected image"
                     ]
                     []
         , span
-            [ HA.class "page-view-choice-label" ]
+            [ HA.class "diva-page-view-choice-label" ]
             [ text image.label ]
         ]
 
@@ -633,7 +633,7 @@ viewImageChoiceItem auth selectedIndex index image =
 viewImageChoicesSidebar : Auth.Model -> List PageImage -> Int -> Html Msg
 viewImageChoicesSidebar auth images selectedIndex =
     div
-        [ HA.class "page-view-choices" ]
+        [ HA.class "diva-page-view-choices" ]
         (List.indexedMap (\index image -> Lazy.lazy4 viewImageChoiceItem auth selectedIndex index image) images)
 
 
@@ -656,7 +656,7 @@ viewModalBody model =
     in
     div
         [ classList
-            [ ( "modal-body", True )
+            [ ( "diva-modal-body", True )
             , ( "is-no-gap", True )
             , ( "is-fullscreen", model.pageViewFullscreen )
             , ( "is-with-choices", hasChoices )
@@ -723,25 +723,25 @@ viewModalHeader model =
                 ( Icons.showSidebar, "Show filters" )
     in
     div
-        [ HA.class "modal-header" ]
+        [ HA.class "diva-modal-header" ]
         [ div
-            [ HA.class "modal-title-stack" ]
-            (div [ HA.class "modal-title" ] [ text "Page View" ]
+            [ HA.class "diva-modal-title-stack" ]
+            (div [ HA.class "diva-modal-title" ] [ text "Page View" ]
                 :: (if String.isEmpty manifestTitle then
                         []
 
                     else
-                        [ div [ HA.class "modal-subtitle" ] [ text manifestTitle ] ]
+                        [ div [ HA.class "diva-modal-subtitle" ] [ text manifestTitle ] ]
                    )
                 ++ (if String.isEmpty pageLabel then
                         []
 
                     else
-                        [ div [ HA.class "modal-subtitle is-muted" ] [ text pageLabel ] ]
+                        [ div [ HA.class "diva-modal-subtitle is-muted" ] [ text pageLabel ] ]
                    )
             )
         , div
-            [ HA.class "modal-actions" ]
+            [ HA.class "diva-modal-actions" ]
             [ viewButton
                 { label = "Previous Page"
                 , icon = Icons.prevPage
@@ -779,7 +779,7 @@ viewModalHeader model =
                 , isFullscreen = model.fullscreen
                 }
             , div
-                [ HA.class "modal-close-action" ]
+                [ HA.class "diva-modal-close-action" ]
                 [ viewButton
                     { label = "Close"
                     , icon = Icons.close
@@ -794,7 +794,7 @@ viewModalHeader model =
 viewModalSidebar : Model -> Html Msg
 viewModalSidebar model =
     div
-        [ HA.class "modal-sidebar" ]
+        [ HA.class "diva-modal-sidebar" ]
         [ Lazy.lazy viewTransformGroup model
         , Lazy.lazy viewToneGroup model
         , Lazy.lazy viewColourAdjustGroup model
@@ -813,13 +813,13 @@ viewModalViewer : Bool -> Bool -> Html Msg
 viewModalViewer fullscreen isOuterLeft =
     div
         [ classList
-            [ ( "modal-viewer", True )
+            [ ( "diva-modal-viewer", True )
             , ( "is-fullscreen", fullscreen )
             , ( "is-outer-left", isOuterLeft )
             ]
         ]
         [ div
-            [ HA.class "modal-canvas"
+            [ HA.class "diva-modal-canvas"
             , id "filter-viewer"
             ]
             []
@@ -899,9 +899,9 @@ viewPseudoColourGroup model =
         , viewFilterRow
             [ viewToggle "Replace Colour" model.filters.colourReplaceEnabled ToggleColourReplace ]
         , viewFilterRow
-            [ span [ HA.class "filter-label" ] [ text "Source" ]
+            [ span [ HA.class "diva-filter-label" ] [ text "Source" ]
             , viewColourInput model.filters.colourReplaceSource (UserUpdatedFilterString StringColourReplaceSource)
-            , span [ HA.class "filter-label" ] [ text "Target" ]
+            , span [ HA.class "diva-filter-label" ] [ text "Target" ]
             , viewColourInput model.filters.colourReplaceTarget (UserUpdatedFilterString StringColourReplaceTarget)
             ]
         , viewRangeRow
@@ -946,15 +946,15 @@ viewRangeInput minValue maxValue stepValue currentValue onChange =
                 Nothing ->
                     baseAttrs
     in
-    input (HA.class "filter-range-input" :: attrs) []
+    input (HA.class "diva-filter-range-input" :: attrs) []
 
 
 viewRangeRow : RangeRowConfig -> Html Msg
 viewRangeRow config =
-    div [ HA.class "filter-range-group" ]
-        [ div [ HA.class "filter-range-header" ]
-            [ span [ HA.class "filter-label" ] [ text config.label ]
-            , span [ HA.class "filter-value" ] [ text config.display ]
+    div [ HA.class "diva-filter-range-group" ]
+        [ div [ HA.class "diva-filter-range-header" ]
+            [ span [ HA.class "diva-filter-label" ] [ text config.label ]
+            , span [ HA.class "diva-filter-value" ] [ text config.display ]
             ]
         , viewRangeInput config.min config.max config.step config.value config.onInput
         ]
@@ -962,14 +962,14 @@ viewRangeRow config =
 
 viewRotationRow : Model -> Html Msg
 viewRotationRow model =
-    div [ HA.class "filter-range-group" ]
-        [ div [ HA.class "filter-range-header" ]
-            [ span [ HA.class "filter-label" ] [ text "Rotation" ]
-            , span [ HA.class "filter-range-header-right" ]
-                [ span [ HA.class "filter-value" ]
+    div [ HA.class "diva-filter-range-group" ]
+        [ div [ HA.class "diva-filter-range-header" ]
+            [ span [ HA.class "diva-filter-label" ] [ text "Rotation" ]
+            , span [ HA.class "diva-filter-range-header-right" ]
+                [ span [ HA.class "diva-filter-value" ]
                     [ text (String.fromInt model.filters.rotation ++ "°") ]
                 , button
-                    [ HA.class "filter-reset"
+                    [ HA.class "diva-filter-reset"
                     , type_ "button"
                     , onClick (UserUpdatedFilterInt IntRotation "0")
                     ]
@@ -987,7 +987,7 @@ viewRotationRow model =
 viewSelect : String -> (String -> Msg) -> List (Html Msg) -> Html Msg
 viewSelect currentValue onChange options =
     select
-        [ HA.class "filter-select"
+        [ HA.class "diva-filter-select"
         , onInput onChange
         , value currentValue
         ]
@@ -996,7 +996,7 @@ viewSelect currentValue onChange options =
 
 viewToggle : String -> Bool -> FilterToggle -> Html Msg
 viewToggle labelText isChecked toggle =
-    label [ HA.class "filter-toggle" ]
+    label [ HA.class "diva-filter-toggle" ]
         [ input
             [ type_ "checkbox"
             , checked isChecked
@@ -1009,9 +1009,9 @@ viewToggle labelText isChecked toggle =
 
 viewToggleRangeRow : ToggleRangeRowConfig -> Html Msg
 viewToggleRangeRow config =
-    div [ HA.class "filter-range-group" ]
-        [ div [ HA.class "filter-range-header" ]
-            [ label [ HA.class "filter-toggle is-inline" ]
+    div [ HA.class "diva-filter-range-group" ]
+        [ div [ HA.class "diva-filter-range-header" ]
+            [ label [ HA.class "diva-filter-toggle is-inline" ]
                 [ input
                     [ type_ "checkbox"
                     , checked config.checked
@@ -1020,7 +1020,7 @@ viewToggleRangeRow config =
                     []
                 , text config.label
                 ]
-            , span [ HA.class "filter-value" ] [ text config.display ]
+            , span [ HA.class "diva-filter-value" ] [ text config.display ]
             ]
         , viewRangeInput config.min config.max config.step config.value config.onInput
         ]

--- a/src/View/Sidebar.elm
+++ b/src/View/Sidebar.elm
@@ -106,12 +106,12 @@ homepageEntries language manifest =
 
             else
                 [ div
-                    [ HA.class "metadata-item" ]
+                    [ HA.class "diva-metadata-item" ]
                     [ div
-                        [ HA.class "metadata-label" ]
+                        [ HA.class "diva-metadata-label" ]
                         [ text "Homepage" ]
                     , div
-                        [ HA.class "metadata-value" ]
+                        [ HA.class "diva-metadata-value" ]
                         (List.map (homepageLinkBlock language) links)
                     ]
                 ]
@@ -167,12 +167,12 @@ metadataEntries language manifest =
 metadataEntry : Language -> LabelValue -> Html Msg
 metadataEntry language entry =
     div
-        [ HA.class "metadata-item" ]
+        [ HA.class "diva-metadata-item" ]
         [ div
-            [ HA.class "metadata-label" ]
+            [ HA.class "diva-metadata-label" ]
             [ extractLabelFromLanguageMap language entry.label |> text ]
         , div
-            [ HA.class "metadata-value" ]
+            [ HA.class "diva-metadata-value" ]
             (extractLabelFromLanguageMap language entry.value |> renderHtml)
         ]
 
@@ -357,11 +357,11 @@ viewContentsToggle viewMode contentsView =
 viewMetadataContent : Model -> Html Msg
 viewMetadataContent model =
     div
-        [ HA.class "metadata-panel" ]
+        [ HA.class "diva-metadata-panel" ]
         (case currentManifest model of
             Just manifest ->
                 [ div
-                    [ HA.class "metadata-body" ]
+                    [ HA.class "diva-metadata-body" ]
                     (metadataEntries model.detectedLanguage manifest
                         ++ homepageEntries model.detectedLanguage manifest
                     )
@@ -369,7 +369,7 @@ viewMetadataContent model =
 
             Nothing ->
                 [ div
-                    [ HA.class "metadata-body" ]
+                    [ HA.class "diva-metadata-body" ]
                     [ text "No metadata available." ]
                 ]
         )
@@ -396,7 +396,7 @@ viewOnThisPageBody model manifest =
                                     |> Dict.fromList
                         in
                         ul
-                            [ HA.class "contents-list list-reset" ]
+                            [ HA.class "contents-list diva-list-reset" ]
                             (List.map (viewOtpRangeItem model canvasLabelMap) matches)
 
                 Nothing ->
@@ -470,7 +470,7 @@ viewRangeButton isCurrent maybeIndex labelText =
     button
         ([ classList
             [ ( "contents-button", True )
-            , ( "ui-button", True )
+            , ( "diva-ui-button", True )
             , ( "is-current", isCurrent )
             ]
          , type_ "button"
@@ -489,7 +489,7 @@ viewRangeButton isCurrent maybeIndex labelText =
 viewRangeDisclosure : Bool -> String -> String -> Html Msg
 viewRangeDisclosure isExpanded rangeId labelText =
     button
-        [ HA.class "contents-disclosure ui-button"
+        [ HA.class "contents-disclosure diva-ui-button"
         , type_ "button"
         , attribute "aria-expanded"
             (if isExpanded then
@@ -538,13 +538,13 @@ viewRangeItems model rangeIndexMap items =
         []
 
     else
-        [ ul [ HA.class "contents-list-nested list-reset" ] rendered ]
+        [ ul [ HA.class "contents-list-nested diva-list-reset" ] rendered ]
 
 
 viewRangeList : Model -> Dict String (Maybe Int) -> List Range -> Html Msg
 viewRangeList model rangeIndexMap ranges =
     ul
-        [ HA.class "contents-list list-reset" ]
+        [ HA.class "contents-list diva-list-reset" ]
         (List.map (Lazy.lazy3 viewRangeNode model rangeIndexMap) ranges)
 
 
@@ -749,9 +749,9 @@ viewThumbnail auth viewMode shiftByOne selectedIndex index page =
 
         attrs =
             [ classList
-                [ ( "thumbs-item", True )
-                , ( "ui-card", True )
-                , ( "ui-card--dark", True )
+                [ ( "diva-thumbs-item", True )
+                , ( "diva-ui-card", True )
+                , ( "diva-ui-card--dark", True )
                 , ( "is-active", isActive )
                 ]
             , type_ "button"
@@ -784,7 +784,7 @@ viewThumbnail auth viewMode shiftByOne selectedIndex index page =
             case Auth.thumbnailCrossOrigin primary.sourceId auth of
                 Just crossOrigin ->
                     Html.node "diva-lazy-image"
-                        [ HA.class "thumbs-lazy-image"
+                        [ HA.class "diva-thumbs-lazy-image"
                         , attribute "data-src" page.thumbUrl
                         , attribute "data-alt" ("Page " ++ String.fromInt (index + 1))
                         , attribute "data-crossorigin" crossOrigin
@@ -793,7 +793,7 @@ viewThumbnail auth viewMode shiftByOne selectedIndex index page =
 
                 Nothing ->
                     div
-                        [ HA.class "thumbs-image thumbs-image--protected"
+                        [ HA.class "diva-thumbs-image diva-thumbs-image--protected"
                         , attribute "aria-label" "Protected image"
                         ]
                         []
@@ -802,7 +802,7 @@ viewThumbnail auth viewMode shiftByOne selectedIndex index page =
         [ thumbnail
         , div
             [ classList
-                [ ( "thumbs-label", True )
+                [ ( "diva-thumbs-label", True )
                 , ( "is-active", isActive )
                 ]
             ]
@@ -842,7 +842,7 @@ viewThumbnails { fullscreen, auth, selectedIndex, shiftByOne, thumbsInstantScrol
     in
     div
         [ classList
-            [ ( "thumbs", True )
+            [ ( "diva-thumbs", True )
             , ( "is-fullscreen", fullscreen )
             ]
         , id "thumbs"

--- a/src/View/Sidebar.elm
+++ b/src/View/Sidebar.elm
@@ -31,7 +31,7 @@ viewSidebarResizer model =
     if shouldRenderSidebarShell model then
         div
             [ classList
-                [ ( "sidebar-resizer", True )
+                [ ( "diva-sidebar-resizer", True )
                 , ( "is-hidden", not (isSidebarVisible model.sidebarState) )
                 ]
             , Events.on "mousedown"
@@ -288,8 +288,8 @@ viewContentsContent model =
                     viewOnThisPageEmptyBody
     in
     div
-        [ HA.class "contents-panel" ]
-        [ div [ HA.class "contents-title" ] [ text "Contents" ]
+        [ HA.class "diva-contents-panel" ]
+        [ div [ HA.class "diva-contents-title" ] [ text "Contents" ]
         , viewContentsToggle model.viewMode model.contentsView
         , body
         ]
@@ -298,7 +298,7 @@ viewContentsContent model =
 viewContentsEmpty : String -> Html Msg
 viewContentsEmpty message =
     div
-        [ HA.class "contents-empty" ]
+        [ HA.class "diva-contents-empty" ]
         [ text message ]
 
 
@@ -324,10 +324,10 @@ viewContentsIndexBody model manifest =
 viewContentsToggle : ViewMode -> ContentsView -> Html Msg
 viewContentsToggle viewMode contentsView =
     div
-        [ HA.class "contents-view-tabs" ]
+        [ HA.class "diva-contents-view-tabs" ]
         [ button
             [ classList
-                [ ( "contents-view-button", True )
+                [ ( "diva-contents-view-button", True )
                 , ( "is-active", contentsView == ContentsIndex )
                 ]
             , type_ "button"
@@ -336,7 +336,7 @@ viewContentsToggle viewMode contentsView =
             [ text "Index" ]
         , button
             [ classList
-                [ ( "contents-view-button", True )
+                [ ( "diva-contents-view-button", True )
                 , ( "is-active", contentsView == ContentsPages )
                 ]
             , type_ "button"
@@ -396,7 +396,7 @@ viewOnThisPageBody model manifest =
                                     |> Dict.fromList
                         in
                         ul
-                            [ HA.class "contents-list diva-list-reset" ]
+                            [ HA.class "diva-contents-list diva-list-reset" ]
                             (List.map (viewOtpRangeItem model canvasLabelMap) matches)
 
                 Nothing ->
@@ -461,7 +461,7 @@ viewOtpRangeItem model canvasLabelMap range =
             viewRangeMetadata model.detectedLanguage range.metadata
     in
     li
-        [ HA.class "contents-item" ]
+        [ HA.class "diva-contents-item" ]
         (labelNode :: metadataBlock)
 
 
@@ -469,7 +469,7 @@ viewRangeButton : Bool -> Maybe Int -> String -> Html Msg
 viewRangeButton isCurrent maybeIndex labelText =
     button
         ([ classList
-            [ ( "contents-button", True )
+            [ ( "diva-contents-button", True )
             , ( "diva-ui-button", True )
             , ( "is-current", isCurrent )
             ]
@@ -489,7 +489,7 @@ viewRangeButton isCurrent maybeIndex labelText =
 viewRangeDisclosure : Bool -> String -> String -> Html Msg
 viewRangeDisclosure isExpanded rangeId labelText =
     button
-        [ HA.class "contents-disclosure diva-ui-button"
+        [ HA.class "diva-contents-disclosure diva-ui-button"
         , type_ "button"
         , attribute "aria-expanded"
             (if isExpanded then
@@ -538,13 +538,13 @@ viewRangeItems model rangeIndexMap items =
         []
 
     else
-        [ ul [ HA.class "contents-list-nested diva-list-reset" ] rendered ]
+        [ ul [ HA.class "diva-contents-list-nested diva-list-reset" ] rendered ]
 
 
 viewRangeList : Model -> Dict String (Maybe Int) -> List Range -> Html Msg
 viewRangeList model rangeIndexMap ranges =
     ul
-        [ HA.class "contents-list diva-list-reset" ]
+        [ HA.class "diva-contents-list diva-list-reset" ]
         (List.map (Lazy.lazy3 viewRangeNode model rangeIndexMap) ranges)
 
 
@@ -555,7 +555,7 @@ viewRangeMetadata language metadata =
 
     else
         [ div
-            [ HA.class "contents-meta" ]
+            [ HA.class "diva-contents-meta" ]
             (List.map (metadataEntry language) metadata)
         ]
 
@@ -591,7 +591,7 @@ viewRangeNode model rangeIndexMap range =
 
         headingNode =
             div
-                [ HA.class "contents-heading" ]
+                [ HA.class "diva-contents-heading" ]
                 ((if List.isEmpty range.metadata then
                     []
 
@@ -609,7 +609,7 @@ viewRangeNode model rangeIndexMap range =
                 []
     in
     li
-        [ HA.class "contents-item" ]
+        [ HA.class "diva-contents-item" ]
         (headingNode :: metadataBlock ++ children)
 
 
@@ -617,7 +617,7 @@ viewSidebarPane : SidebarState -> SidebarState -> Html Msg -> Html Msg
 viewSidebarPane current target content =
     div
         [ classList
-            [ ( "sidebar-pane", True )
+            [ ( "diva-sidebar-pane", True )
             , ( "is-hidden", current /= target )
             ]
         ]
@@ -656,7 +656,7 @@ viewSidebarPanelWithMaybeManifest model maybeManifest =
                 model.pages
 
         panelClasses =
-            [ ( "sidebar-panel", True )
+            [ ( "diva-sidebar-panel", True )
             , ( "is-fullscreen", model.fullscreen )
             , ( "is-hidden", not (isSidebarVisible model.sidebarState) )
             , ( "is-overlay", model.mobileSidebarOpen )
@@ -702,13 +702,13 @@ viewSidebarPanelWithMaybeManifest model maybeManifest =
             )
         ]
         [ div
-            [ HA.class "sidebar-tabs" ]
+            [ HA.class "diva-sidebar-tabs" ]
             (viewSidebarTab model.sidebarState SidebarThumbnails "Thumbnails" UserToggledThumbnails
                 :: metadataTab
                 ++ contentsTab
             )
         , div
-            [ HA.class "sidebar-content" ]
+            [ HA.class "diva-sidebar-content" ]
             (viewSidebarPane model.sidebarState
                 SidebarThumbnails
                 (viewThumbnails
@@ -732,7 +732,7 @@ viewSidebarTab : SidebarState -> SidebarState -> String -> Msg -> Html Msg
 viewSidebarTab current target label msg =
     button
         [ classList
-            [ ( "sidebar-tab-button", True )
+            [ ( "diva-sidebar-tab-button", True )
             , ( "is-active", current == target )
             ]
         , type_ "button"

--- a/src/View/Toolbar.elm
+++ b/src/View/Toolbar.elm
@@ -215,7 +215,7 @@ viewCurrentLabel : Bool -> String -> Html Msg
 viewCurrentLabel fullscreen labelText =
     div
         [ classList
-            [ ( "canvas-label", True )
+            [ ( "diva-canvas-label", True )
             , ( "is-fullscreen", fullscreen )
             ]
         ]

--- a/src/View/Toolbar.elm
+++ b/src/View/Toolbar.elm
@@ -21,9 +21,9 @@ viewToolbar model =
         currentLabelText =
             currentLabelFor model
     in
-    div [ HA.class "canvas-toolbar-stack" ]
-        [ div [ HA.class "canvas-toolbar" ]
-            [ div [ HA.class "canvas-toolbar-section" ]
+    div [ HA.class "diva-canvas-toolbar-stack" ]
+        [ div [ HA.class "diva-canvas-toolbar" ]
+            [ div [ HA.class "diva-canvas-toolbar-section" ]
                 [ viewCollectionSidebarButton model
                 , viewButton
                     { label = "Zoom Out"
@@ -38,9 +38,9 @@ viewToolbar model =
                     , isFullscreen = model.fullscreen
                     }
                 ]
-            , div [ HA.class "canvas-toolbar-end" ]
+            , div [ HA.class "diva-canvas-toolbar-end" ]
                 [ Lazy.lazy2 viewCurrentLabel model.fullscreen currentLabelText
-                , div [ HA.class "canvas-toolbar-section is-right" ]
+                , div [ HA.class "diva-canvas-toolbar-section is-right" ]
                     (viewLogoutActions model
                         ++ [ viewButton
                                 { label = "Page View"
@@ -242,11 +242,11 @@ viewLogoutActions model =
                                 label
                 in
                 div
-                    [ HA.class "canvas-toolbar-item"
+                    [ HA.class "diva-canvas-toolbar-item"
                     , HA.attribute "data-tooltip" displayLabel
                     ]
                     [ button
-                        [ HA.class "canvas-toolbar-button"
+                        [ HA.class "diva-canvas-toolbar-button"
                         , HA.type_ "button"
                         , HA.attribute "aria-label" displayLabel
                         , HA.attribute "data-diva-auth-logout" action.sessionId

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -171,14 +171,14 @@
   margin-bottom: 0;
 }
 
-.contents-empty {
+.diva-contents-empty {
   padding-left: 12px;
   font-size: var(--diva-font-lg);
   color: var(--diva-text-muted);
 }
 
-.sidebar-resizer,
-.collection-resizer {
+.diva-sidebar-resizer,
+.diva-collection-resizer {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -194,19 +194,19 @@
   align-self: stretch;
 }
 
-.sidebar-resizer.is-hidden,
-.collection-resizer.is-hidden {
+.diva-sidebar-resizer.is-hidden,
+.diva-collection-resizer.is-hidden {
   display: none;
 }
 
-.sidebar-panel.is-fullscreen,
-.collection-panel.is-fullscreen {
+.diva-sidebar-panel.is-fullscreen,
+.diva-collection-panel.is-fullscreen {
   height: 100%;
   border-radius: 0;
 }
 
-.sidebar-panel.is-hidden,
-.collection-panel.is-hidden {
+.diva-sidebar-panel.is-hidden,
+.diva-collection-panel.is-hidden {
   border-width: 0;
   padding: 0;
   opacity: 0;
@@ -331,8 +331,8 @@
     gap: 12px;
   }
 
-  .sidebar-resizer,
-  .collection-resizer {
+  .diva-sidebar-resizer,
+  .diva-collection-resizer {
     display: none;
   }
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,20 +1,21 @@
 /* App layout, canvas, and throbber styles. */
 
-:root {
+.diva-app {
   color-scheme: light;
 }
 
-* {
+.diva-app,
+.diva-app * {
   box-sizing: border-box;
 }
 
-.list-reset {
+.diva-list-reset {
   list-style: none;
   padding: 0;
   margin: 0;
 }
 
-.ui-button {
+.diva-ui-button {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -24,18 +25,18 @@
   font-size: var(--diva-font-lg);
 }
 
-.ui-button:hover {
+.diva-ui-button:hover {
   background-color: var(--diva-surface);
 }
 
-.ui-card {
+.diva-ui-card {
   border-radius: 0;
   padding: 6px;
   cursor: pointer;
   width: 100%;
 }
 
-.ui-card--dark {
+.diva-ui-card--dark {
   background-color: var(--diva-dark-bg);
 }
 
@@ -129,25 +130,25 @@
   border-radius: 0;
 }
 
-.metadata-panel {
+.diva-metadata-panel {
   padding: 12px;
   height: 100%;
   overflow: auto;
 }
 
-.metadata-body {
+.diva-metadata-body {
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
-.metadata-item {
+.diva-metadata-item {
   display: flex;
   flex-direction: column;
   gap: 0;
 }
 
-.metadata-label {
+.diva-metadata-label {
   font-size: var(--diva-font-lg);
   font-weight: 600;
   color: var(--diva-text-muted);
@@ -155,18 +156,18 @@
   line-height: 1.3;
 }
 
-.metadata-value {
+.diva-metadata-value {
   font-size: var(--diva-font-lg);
   color: var(--diva-text-muted);
   line-height: 1.3;
   padding-left: 12px;
 }
 
-.metadata-value > :first-child {
+.diva-metadata-value > :first-child {
   margin-top: 0;
 }
 
-.metadata-value > :last-child {
+.diva-metadata-value > :last-child {
   margin-bottom: 0;
 }
 
@@ -213,7 +214,7 @@
   overflow: hidden;
 }
 
-.required-statement-dock {
+.diva-required-statement-dock {
   display: flex;
   justify-content: flex-end;
   width: 100%;
@@ -221,7 +222,7 @@
   padding-right: 8px;
 }
 
-.required-statement {
+.diva-required-statement {
   font-size: var(--diva-font-md);
   color: var(--diva-text-muted);
   line-height: 1.4;
@@ -261,7 +262,7 @@
   background: var(--diva-dark-border);
 }
 
-.throbber-overlay {
+.diva-throbber-overlay {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -270,7 +271,7 @@
   pointer-events: none;
 }
 
-.viewer-zoom-indicator {
+.diva-viewer-zoom-indicator {
   position: absolute;
   left: 12px;
   bottom: 12px;
@@ -284,7 +285,7 @@
   background-color: rgb(0 0 0 / 55%);
 }
 
-.throbber {
+.diva-throbber {
   width: 64px;
   height: 64px;
   padding: 8px;
@@ -295,7 +296,7 @@
   flex-wrap: wrap;
 }
 
-.throbber-cube {
+.diva-throbber-cube {
   width: 16px;
   height: 16px;
   background-color: var(--diva-accent);

--- a/src/styles/collection.css
+++ b/src/styles/collection.css
@@ -1,6 +1,6 @@
 /* Collection sidebar styles. */
 
-.collection-panel {
+.diva-collection-panel {
   height: 100%;
   min-height: 0;
   display: flex;
@@ -11,31 +11,31 @@
   overflow: hidden;
 }
 
-.collection-header {
+.diva-collection-header {
   padding: 12px;
   border-radius: 0;
   background-color: var(--diva-surface);
   border-bottom: 1px solid var(--diva-border);
 }
 
-.collection-title {
+.diva-collection-title {
   font-size: var(--diva-font-lg);
   font-weight: 600;
   color: var(--diva-text-muted);
   margin-bottom: 4px;
 }
 
-.collection-summary {
+.diva-collection-summary {
   font-size: var(--diva-font-md);
   color: var(--diva-text-muted);
   line-height: 1.4;
 }
 
-.collection-tree-item {
+.diva-collection-tree-item {
   padding-left: 12px;
 }
 
-.collection-node-button {
+.diva-collection-node-button {
   padding: 6px 8px;
   width: 100%;
   display: flex;
@@ -43,7 +43,7 @@
   gap: 6px;
 }
 
-.collection-expand-icon {
+.diva-collection-expand-icon {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -52,21 +52,21 @@
   flex-shrink: 0;
 }
 
-.manifest-tree-item {
+.diva-manifest-tree-item {
   padding: 6px 8px 6px 30px;
 }
 
-.manifest-tree-item.is-active {
+.diva-manifest-tree-item.is-active {
   background-color: var(--diva-border);
   font-weight: 600;
 }
 
-.sidebar-pane.is-scroll {
+.diva-sidebar-pane.is-scroll {
   overflow-y: auto;
 }
 
 @media (max-width: 720px) {
-  .collection-panel {
+  .diva-collection-panel {
     width: 100%;
     height: auto;
     border-radius: 0;

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -65,7 +65,7 @@
   gap: 8px;
 }
 
-.diva-modal-close-action .canvas-toolbar-button {
+.diva-modal-close-action .diva-canvas-toolbar-button {
   background-color: transparent;
   color: var(--diva-danger);
   border: none;
@@ -77,12 +77,12 @@
   padding: 2px;
 }
 
-.diva-modal-close-action .canvas-toolbar-button:hover {
+.diva-modal-close-action .diva-canvas-toolbar-button:hover {
   background-color: rgb(211 47 47 / 12%);
   border-color: transparent;
 }
 
-.diva-modal-close-action .canvas-toolbar-item {
+.diva-modal-close-action .diva-canvas-toolbar-item {
   width: 32px;
 }
 

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -1,6 +1,6 @@
 /* Modal and filter panel styles (Page View + Manifest Info). */
 
-.modal-overlay {
+.diva-modal-overlay {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -11,7 +11,7 @@
   z-index: 100;
 }
 
-.viewer-status-overlay {
+.diva-viewer-status-overlay {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -22,11 +22,11 @@
   z-index: 40;
 }
 
-.modal-overlay.is-fullscreen {
+.diva-modal-overlay.is-fullscreen {
   padding: 0;
 }
 
-.modal {
+.diva-modal {
   background-color: var(--diva-page-bg);
   color: var(--diva-text-primary);
   border-radius: 0;
@@ -37,35 +37,35 @@
   box-shadow: 0 20px 40px var(--diva-shadow-modal);
 }
 
-.modal.is-narrow {
+.diva-modal.is-narrow {
   width: min(960px, 94vw);
 }
 
-.modal.is-page-view {
+.diva-modal.is-page-view {
   height: 80vh;
   max-height: 80vh;
 }
 
-.modal.is-fullscreen {
+.diva-modal.is-fullscreen {
   border-radius: 0;
   width: 100vw;
   height: 100vh;
   max-height: 100vh;
 }
 
-.modal-header {
+.diva-modal-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 16px 20px 0 20px;
 }
 
-.modal-actions {
+.diva-modal-actions {
   display: flex;
   gap: 8px;
 }
 
-.modal-close-action .canvas-toolbar-button {
+.diva-modal-close-action .canvas-toolbar-button {
   background-color: transparent;
   color: var(--diva-danger);
   border: none;
@@ -77,36 +77,36 @@
   padding: 2px;
 }
 
-.modal-close-action .canvas-toolbar-button:hover {
+.diva-modal-close-action .canvas-toolbar-button:hover {
   background-color: rgb(211 47 47 / 12%);
   border-color: transparent;
 }
 
-.modal-close-action .canvas-toolbar-item {
+.diva-modal-close-action .canvas-toolbar-item {
   width: 32px;
 }
 
-.modal-title-stack {
+.diva-modal-title-stack {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.modal-title {
+.diva-modal-title {
   font-size: var(--diva-font-lg);
   font-weight: 600;
 }
 
-.modal-subtitle {
+.diva-modal-subtitle {
   font-size: var(--diva-font-lg);
   color: var(--diva-text-primary);
 }
 
-.modal-subtitle.is-muted {
+.diva-modal-subtitle.is-muted {
   font-size: var(--diva-font-md);
 }
 
-.modal-body {
+.diva-modal-body {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 240px;
   gap: 16px;
@@ -115,55 +115,55 @@
   min-height: 0;
 }
 
-.modal-body.is-no-gap {
+.diva-modal-body.is-no-gap {
   gap: 0;
 }
 
-.modal-body.is-two-column {
+.diva-modal-body.is-two-column {
   grid-template-columns: minmax(0, 1fr) 200px;
   align-items: start;
 }
 
-.modal-body.is-no-sidebar {
+.diva-modal-body.is-no-sidebar {
   grid-template-columns: minmax(0, 1fr);
 }
 
-.modal-body.is-fullscreen {
+.diva-modal-body.is-fullscreen {
   flex: 1;
   min-height: 0;
 }
 
-.modal-body.is-with-choices {
+.diva-modal-body.is-with-choices {
   grid-template-columns: 120px minmax(0, 1fr) 240px;
 }
 
-.modal-body.is-with-choices-no-sidebar {
+.diva-modal-body.is-with-choices-no-sidebar {
   grid-template-columns: 120px minmax(0, 1fr);
 }
 
-.modal-viewer {
+.diva-modal-viewer {
   background-color: var(--diva-dark-bg);
   overflow: hidden;
   border: 1px solid var(--diva-dark-border);
   height: 100%;
 }
 
-.modal-viewer.is-fullscreen {
+.diva-modal-viewer.is-fullscreen {
   height: 100%;
   border-radius: 0;
 }
 
-.modal-viewer.is-outer-left {
+.diva-modal-viewer.is-outer-left {
   border-radius: 0;
 }
 
-.modal-canvas {
+.diva-modal-canvas {
   display: block;
   width: 100%;
   height: 100%;
 }
 
-.modal-sidebar {
+.diva-modal-sidebar {
   background-color: var(--diva-white);
   border-top: 1px solid var(--diva-border);
   border-right: 1px solid var(--diva-border);
@@ -173,7 +173,7 @@
   overflow: auto;
 }
 
-.manifest-info-logo-wrap {
+.diva-manifest-info-logo-wrap {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -181,13 +181,13 @@
   text-align: center;
 }
 
-.manifest-info-logo {
+.diva-manifest-info-logo {
   width: 100%;
   height: auto;
   max-width: 180px;
 }
 
-.page-view-choices {
+.diva-page-view-choices {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -197,40 +197,40 @@
   overflow: auto;
 }
 
-.page-view-choice {
+.diva-page-view-choice {
   border: 2px solid transparent;
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.page-view-choice:focus-visible {
+.diva-page-view-choice:focus-visible {
   outline: 2px solid var(--diva-accent);
   outline-offset: 2px;
 }
 
-.page-view-choice:hover {
+.diva-page-view-choice:hover {
   background-color: var(--diva-dark-bg);
 }
 
-.page-view-choice.is-active {
+.diva-page-view-choice.is-active {
   border-color: var(--diva-accent-light);
   background-color: var(--diva-dark-bg);
 }
 
-.page-view-choice-thumb {
+.diva-page-view-choice-thumb {
   display: block;
   width: 100%;
   height: auto;
   border-radius: 0;
 }
 
-.page-view-choice-thumb--protected {
+.diva-page-view-choice-thumb--protected {
   min-height: 72px;
   background: var(--diva-dark-bg);
 }
 
-.page-view-choice-label {
+.diva-page-view-choice-label {
   font-size: var(--diva-font-xs);
   line-height: 1.2;
   color: var(--diva-text-muted);
@@ -239,13 +239,13 @@
   white-space: nowrap;
 }
 
-.filter-group {
+.diva-filter-group {
   margin-bottom: 12px;
   padding-bottom: 12px;
   border-bottom: 1px solid var(--diva-border);
 }
 
-.filter-title-button {
+.diva-filter-title-button {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -263,11 +263,11 @@
   margin-bottom: 8px;
 }
 
-.filter-title-button.is-collapsed {
+.diva-filter-title-button.is-collapsed {
   margin-bottom: 0;
 }
 
-.filter-title-icon {
+.diva-filter-title-icon {
   display: inline-block;
   width: 0;
   height: 0;
@@ -277,11 +277,11 @@
   transition: transform 150ms ease;
 }
 
-.filter-title-icon.is-expanded {
+.diva-filter-title-icon.is-expanded {
   transform: rotate(90deg);
 }
 
-.filter-row {
+.diva-filter-row {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
@@ -289,7 +289,7 @@
   margin-bottom: 8px;
 }
 
-.filter-toggle {
+.diva-filter-toggle {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -297,42 +297,42 @@
   margin-bottom: 8px;
 }
 
-.filter-toggle.is-inline {
+.diva-filter-toggle.is-inline {
   margin-bottom: 0;
 }
 
-.filter-range-group {
+.diva-filter-range-group {
   display: flex;
   flex-direction: column;
   gap: 6px;
   margin-bottom: 10px;
 }
 
-.filter-range-header {
+.diva-filter-range-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
 }
 
-.filter-range-header-right {
+.diva-filter-range-header-right {
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.filter-range-input {
+.diva-filter-range-input {
   width: 100%;
 }
 
-.filter-value {
+.diva-filter-value {
   font-size: var(--diva-font-sm);
   color: var(--diva-text-muted);
   width: 40px;
   text-align: right;
 }
 
-.filter-reset {
+.diva-filter-reset {
   font-size: var(--diva-font-xs);
   padding: 2px 6px;
   background-color: var(--diva-surface);
@@ -342,11 +342,11 @@
   color: var(--diva-text-muted);
 }
 
-.filter-reset:hover {
+.diva-filter-reset:hover {
   background-color: var(--diva-border);
 }
 
-.filter-json {
+.diva-filter-json {
   width: 100%;
   min-height: 120px;
   padding: 6px 8px;
@@ -358,18 +358,18 @@
   font-family: Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 }
 
-.filter-json-error {
+.diva-filter-json-error {
   font-size: var(--diva-font-sm);
   color: var(--diva-danger);
   margin-top: 4px;
 }
 
-.filter-label {
+.diva-filter-label {
   font-size: var(--diva-font-sm);
   color: var(--diva-text-muted);
 }
 
-.filter-select {
+.diva-filter-select {
   padding: 4px 6px;
   border-radius: 0;
   border: 1px solid var(--diva-border);
@@ -377,7 +377,7 @@
   font-size: var(--diva-font-sm);
 }
 
-.filter-color-input {
+.diva-filter-color-input {
   width: 42px;
   height: 28px;
   padding: 0;

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -1,6 +1,6 @@
 /* Sidebar-only styles to replace elm-css for the sidebar components. */
 
-.sidebar-panel {
+.diva-sidebar-panel {
   width: 320px;
   height: 100%;
   display: flex;
@@ -12,22 +12,22 @@
   overflow: hidden;
 }
 
-.sidebar-panel.is-overlay {
+.diva-sidebar-panel.is-overlay {
   /* mobile-only overlay styles are applied in the media query below */
 }
 
-.sidebar-panel.is-mobile-hidden {
+.diva-sidebar-panel.is-mobile-hidden {
   /* mobile-only hidden styles are applied in the media query below */
 }
 
-.sidebar-tabs {
+.diva-sidebar-tabs {
   display: flex;
   border: 1px solid var(--diva-surface);
   border-radius: 0;
   background-color: var(--diva-surface);
 }
 
-.sidebar-tab-button {
+.diva-sidebar-tab-button {
   flex: 1;
   background-color: transparent;
   border: none;
@@ -38,12 +38,12 @@
   color: var(--diva-text-muted);
 }
 
-.sidebar-tab-button.is-active {
+.diva-sidebar-tab-button.is-active {
   background-color: var(--diva-white);
   font-weight: 600;
 }
 
-.sidebar-content {
+.diva-sidebar-content {
   flex: 1;
   min-height: 0;
   background-color: var(--diva-page-bg);
@@ -53,13 +53,13 @@
   flex-direction: column;
 }
 
-.sidebar-pane {
+.diva-sidebar-pane {
   width: 100%;
   flex: 1;
   min-height: 0;
 }
 
-.sidebar-pane.is-hidden {
+.diva-sidebar-pane.is-hidden {
   display: none;
 }
 
@@ -135,26 +135,26 @@
   color: var(--diva-white);
 }
 
-.contents-panel {
+.diva-contents-panel {
   height: 100%;
   overflow: auto;
   padding: 12px;
 }
 
-.contents-title {
+.diva-contents-title {
   font-size: var(--diva-font-lg);
   font-weight: 600;
   color: var(--diva-text-muted);
   margin-bottom: 10px;
 }
 
-.contents-view-tabs {
+.diva-contents-view-tabs {
   display: flex;
   gap: 8px;
   margin-bottom: 12px;
 }
 
-.contents-view-button {
+.diva-contents-view-button {
   background-color: var(--diva-surface);
   border: 1px solid var(--diva-border);
   border-radius: 0;
@@ -164,40 +164,40 @@
   cursor: pointer;
 }
 
-.contents-view-button.is-active {
+.diva-contents-view-button.is-active {
   background-color: var(--diva-white);
   border-color: var(--diva-accent);
   color: var(--diva-text-primary);
 }
 
-.contents-list-nested {
+.diva-contents-list-nested {
   border-left: 1px solid var(--diva-border);
   margin-left: 6px;
   padding-left: 13px;
   margin-top: 6px;
 }
 
-.contents-item {
+.diva-contents-item {
   margin-bottom: 6px;
 }
 
-.contents-heading {
+.diva-contents-heading {
   display: flex;
   align-items: baseline;
 }
 
-.contents-disclosure {
+.diva-contents-disclosure {
   flex: 0 0 1.25rem;
   color: var(--diva-text-muted);
   cursor: pointer;
   text-align: center;
 }
 
-.contents-disclosure:hover {
+.diva-contents-disclosure:hover {
   color: var(--diva-accent);
 }
 
-.contents-meta {
+.diva-contents-meta {
   border: 1px solid var(--diva-dark-border);
   display: flex;
   flex-direction: column;
@@ -206,40 +206,40 @@
   margin-top: 6px;
 }
 
-.contents-meta dl > div + div {
+.diva-contents-meta dl > div + div {
   border-top: 1px solid var(--diva-dark-border);
   margin-top: 0.75rem;
   padding-top: 0.75rem;
 }
 
-.contents-meta dt {
+.diva-contents-meta dt {
   font-weight: 600;
 }
 
-.contents-meta dd {
+.diva-contents-meta dd {
   margin: 0 0 0.5rem 1rem;
 }
 
-.contents-meta dd:last-child {
+.diva-contents-meta dd:last-child {
   margin-bottom: 0;
 }
 
-.contents-button:hover {
+.diva-contents-button:hover {
   color: var(--diva-accent);
 }
 
-.contents-button.is-current {
+.diva-contents-button.is-current {
   font-weight: 600;
 }
 
 @media (max-width: 720px) {
-  .sidebar-panel {
+  .diva-sidebar-panel {
     width: 100% !important;
     height: auto;
     border-radius: 0;
   }
 
-  .sidebar-panel.is-overlay {
+  .diva-sidebar-panel.is-overlay {
     position: absolute;
     top: 0;
     left: 0;
@@ -252,7 +252,7 @@
     box-shadow: 0 12px 24px var(--diva-shadow-dark);
   }
 
-  .sidebar-panel.is-mobile-hidden {
+  .diva-sidebar-panel.is-mobile-hidden {
     display: none;
   }
 

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -63,7 +63,7 @@
   display: none;
 }
 
-.thumbs {
+.diva-thumbs {
   width: 100%;
   height: 100%;
   flex: 1;
@@ -78,11 +78,11 @@
   padding: 12px;
 }
 
-.thumbs.is-fullscreen {
+.diva-thumbs.is-fullscreen {
   height: 100%;
 }
 
-.thumbs-item {
+.diva-thumbs-item {
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -92,12 +92,12 @@
   max-width: none;
 }
 
-.thumbs-item:focus-visible {
+.diva-thumbs-item:focus-visible {
   outline: 2px solid var(--diva-accent);
   outline-offset: 2px;
 }
 
-.thumbs-item.is-active {
+.diva-thumbs-item.is-active {
   border-color: var(--diva-accent-light);
   box-shadow: 0 0 0 var(--diva-shadow-focus);
   background-color: var(--diva-dark-bg);
@@ -105,33 +105,33 @@
   outline-offset: 2px;
 }
 
-.thumbs-image {
+.diva-thumbs-image {
   display: block;
   width: 100%;
   height: auto;
   border-radius: 0;
 }
 
-.thumbs-lazy-image {
+.diva-thumbs-lazy-image {
   display: block;
   width: 100%;
   min-height: 96px;
   background: var(--diva-dark-bg);
 }
 
-.thumbs-image--protected {
+.diva-thumbs-image--protected {
   min-height: 96px;
   background: var(--diva-dark-bg);
 }
 
-.thumbs-label {
+.diva-thumbs-label {
   margin-top: 6px;
   font-size: var(--diva-font-sm);
   line-height: 1.3;
   color: var(--diva-text-muted-on-dark);
 }
 
-.thumbs-label.is-active {
+.diva-thumbs-label.is-active {
   color: var(--diva-white);
 }
 
@@ -256,7 +256,7 @@
     display: none;
   }
 
-  .thumbs {
+  .diva-thumbs {
     width: 100%;
     height: auto;
     grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -264,7 +264,7 @@
     overflow-y: hidden;
   }
 
-  .thumbs-item {
+  .diva-thumbs-item {
     min-width: 120px;
   }
 }

--- a/src/styles/toolbar.css
+++ b/src/styles/toolbar.css
@@ -153,7 +153,7 @@
   transform: translate(0, 0);
 }
 
-.canvas-label {
+.diva-canvas-label {
   font-size: var(--diva-font-lg);
   color: var(--diva-text-muted);
   width: 100%;
@@ -163,7 +163,7 @@
   word-break: break-word;
 }
 
-.canvas-toolbar-end .canvas-label {
+.canvas-toolbar-end .diva-canvas-label {
   flex: 1 1 auto;
   width: auto;
   min-width: 0;
@@ -175,17 +175,17 @@
   word-break: normal;
 }
 
-.canvas-label.is-fullscreen {
+.diva-canvas-label.is-fullscreen {
   color: var(--diva-white);
 }
 
-.status {
+.diva-status {
   font-size: var(--diva-font-lg);
   margin-bottom: 0;
   color: var(--diva-text-muted);
 }
 
-.status.is-error {
+.diva-status.is-error {
   color: var(--diva-danger);
 }
 
@@ -217,11 +217,11 @@
     height: 15px;
   }
 
-  .canvas-label {
+  .diva-canvas-label {
     display: none;
   }
 
-  .status {
+  .diva-status {
     display: none;
   }
 }

--- a/src/styles/toolbar.css
+++ b/src/styles/toolbar.css
@@ -1,6 +1,6 @@
 /* Toolbar-only styles to replace elm-css for the toolbar components. */
 
-.canvas-toolbar-stack {
+.diva-canvas-toolbar-stack {
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -8,14 +8,14 @@
   min-width: 0;
 }
 
-.canvas-toolbar {
+.diva-canvas-toolbar {
   display: flex;
   align-items: center;
   margin-bottom: 0;
   width: 100%;
 }
 
-.canvas-toolbar-section {
+.diva-canvas-toolbar-section {
   display: flex;
   align-items: center;
   gap: 5px;
@@ -23,12 +23,12 @@
   flex: 0 0 auto;
 }
 
-.canvas-toolbar-section.is-right {
+.diva-canvas-toolbar-section.is-right {
   margin-left: auto;
   flex: 0 0 auto;
 }
 
-.canvas-toolbar-end {
+.diva-canvas-toolbar-end {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -36,11 +36,11 @@
   margin-left: auto;
 }
 
-.canvas-toolbar-end .canvas-toolbar-section.is-right {
+.diva-canvas-toolbar-end .diva-canvas-toolbar-section.is-right {
   margin-left: 0;
 }
 
-.canvas-toolbar-item {
+.diva-canvas-toolbar-item {
   position: relative;
   display: flex;
   justify-content: center;
@@ -50,7 +50,7 @@
   flex: 0 0 auto;
 }
 
-.canvas-toolbar-button {
+.diva-canvas-toolbar-button {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -65,49 +65,49 @@
   cursor: pointer;
 }
 
-.canvas-toolbar-button svg {
+.diva-canvas-toolbar-button svg {
   width: 16px;
   height: 16px;
   flex: 0 0 auto;
 }
 
-.canvas-toolbar-button:focus-visible {
+.diva-canvas-toolbar-button:focus-visible {
   outline: 2px solid var(--diva-accent);
   outline-offset: 2px;
 }
 
-.canvas-toolbar-button:hover {
+.diva-canvas-toolbar-button:hover {
   background-color: rgb(214 214 214 / 98%);
   border-color: var(--diva-toolbar-button-icon);
 }
 
-.canvas-toolbar-button.is-fullscreen {
+.diva-canvas-toolbar-button.is-fullscreen {
   color: var(--diva-white);
   background-color: rgb(82 88 98 / 58%);
   border-color: rgb(255 255 255 / 52%);
 }
 
-.canvas-toolbar-button.is-fullscreen:hover {
+.diva-canvas-toolbar-button.is-fullscreen:hover {
   background-color: rgb(96 104 116 / 72%);
   border-color: var(--diva-white);
 }
 
-.canvas-toolbar-button.is-disabled {
+.diva-canvas-toolbar-button.is-disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
 
-.canvas-toolbar-button.is-disabled:hover {
+.diva-canvas-toolbar-button.is-disabled:hover {
   background-color: rgb(226 226 226 / 94%);
   border-color: rgb(44 45 51 / 45%);
 }
 
-.canvas-toolbar-button.is-fullscreen.is-disabled:hover {
+.diva-canvas-toolbar-button.is-fullscreen.is-disabled:hover {
   background-color: rgb(82 88 98 / 58%);
   border-color: rgb(255 255 255 / 52%);
 }
 
-.canvas-toolbar-item::after {
+.diva-canvas-toolbar-item::after {
   position: absolute;
   top: calc(100% + 7px);
   left: 50%;
@@ -135,21 +135,21 @@
   word-break: normal;
 }
 
-.canvas-toolbar-item:hover::after,
-.canvas-toolbar-item:has(.canvas-toolbar-button:focus-visible)::after {
+.diva-canvas-toolbar-item:hover::after,
+.diva-canvas-toolbar-item:has(.diva-canvas-toolbar-button:focus-visible)::after {
   opacity: 1;
   transform: translate(-50%, 0);
   visibility: visible;
 }
 
-.canvas-toolbar-section.is-right .canvas-toolbar-item:last-child::after {
+.diva-canvas-toolbar-section.is-right .diva-canvas-toolbar-item:last-child::after {
   left: auto;
   right: 0;
   transform: translate(0, -3px);
 }
 
-.canvas-toolbar-section.is-right .canvas-toolbar-item:last-child:hover::after,
-.canvas-toolbar-section.is-right .canvas-toolbar-item:last-child:has(.canvas-toolbar-button:focus-visible)::after {
+.diva-canvas-toolbar-section.is-right .diva-canvas-toolbar-item:last-child:hover::after,
+.diva-canvas-toolbar-section.is-right .diva-canvas-toolbar-item:last-child:has(.diva-canvas-toolbar-button:focus-visible)::after {
   transform: translate(0, 0);
 }
 
@@ -163,7 +163,7 @@
   word-break: break-word;
 }
 
-.canvas-toolbar-end .diva-canvas-label {
+.diva-canvas-toolbar-end .diva-canvas-label {
   flex: 1 1 auto;
   width: auto;
   min-width: 0;
@@ -190,29 +190,29 @@
 }
 
 @media (max-width: 720px) {
-  .canvas-toolbar {
+  .diva-canvas-toolbar {
     flex-wrap: wrap;
     gap: 5px;
   }
 
-  .canvas-toolbar-end {
+  .diva-canvas-toolbar-end {
     margin-left: 0;
     width: 100%;
     justify-content: flex-end;
   }
 
-  .canvas-toolbar-item {
+  .diva-canvas-toolbar-item {
     width: 32px;
     height: 32px;
   }
 
-  .canvas-toolbar-button {
+  .diva-canvas-toolbar-button {
     width: 28px;
     height: 28px;
     padding: 6px;
   }
 
-  .canvas-toolbar-button svg {
+  .diva-canvas-toolbar-button svg {
     width: 15px;
     height: 15px;
   }

--- a/src/viewer-element.ts
+++ b/src/viewer-element.ts
@@ -60,7 +60,7 @@ class DivaLazyImage extends HTMLElement
         }
         lazyImageObserver?.unobserve(this);
         const image = document.createElement("img");
-        image.className = "thumbs-image";
+        image.className = "diva-thumbs-image";
         image.alt = this.dataset.alt ?? "";
         const crossOrigin = this.dataset.crossorigin;
         if (crossOrigin)


### PR DESCRIPTION
### Problem

Diva injects its stylesheet into the page at import time, and the rules aren't scoped. They apply to the whole document instead of just the viewer. That includes a `* { box-sizing }` reset, `:root { color-scheme }`, and common class names like `.modal`, `.modal-body`, `.status`, `.thumbs*`, and `.canvas-label`. When Diva is embedded in another app, these collide with the host's own styles.

See #566.

### Fix

Two small changes:

1. Add a `diva-scope` class to the viewer's root element (`src/View.elm`).
2. Scope every rule under that class at build time (`scripts/minify-css.mjs`). The build rewrites each selector so `:root` becomes `.diva-scope`, and everything else becomes a descendant of it. For example, `.modal` becomes `.diva-scope .modal`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Standardized viewer, modal, sidebar, toolbar, thumbnail, and collection interface styling under a consistent `diva-` CSS namespace.
  - Preserved existing visual appearance, responsive layouts, controls, and interactions.

- **Tests**
  - Updated browser tests to use the current styling selectors while preserving existing test coverage and behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->